### PR TITLE
Revert "Bump redcarpet from 3.5.0 to 3.5.1"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -219,7 +219,7 @@ GEM
     plist (3.5.0)
     public_suffix (2.0.5)
     rake (13.0.1)
-    redcarpet (3.5.1)
+    redcarpet (3.5.0)
     representable (3.0.4)
       declarative (< 0.1.0)
       declarative-option (< 0.2.0)


### PR DESCRIPTION
Reverts plaidev/karte-ios-sdk#6